### PR TITLE
feat: add sharing on drawer

### DIFF
--- a/src/components/Common/Drawer/index.tsx
+++ b/src/components/Common/Drawer/index.tsx
@@ -3,6 +3,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React from 'react';
+import { useQuery } from 'react-query';
+import { getUserQuery, User } from '@/api/user';
 import { ROUTES } from '@/constants';
 import close from '@public/assets/common/close.svg';
 import logo from '@public/images/logo.png';
@@ -14,14 +16,20 @@ interface DrawerProps {
 
 const Drawer = ({ closeDrawerHandler, isOpen = false }: DrawerProps) => {
   const router = useRouter();
+  const { data: user } = useQuery<User>(['getUser'], getUserQuery);
+
   const handleClickReTest = () => {
     router.push(ROUTES.HOME);
   };
 
   const shareMyResult = async () => {
+    if (!user) {
+      return;
+    }
+
     if (navigator.share) {
       const title = document.title;
-      const url = document.location.href;
+      const url = `${window.location.origin}${ROUTES.TEST_RESULT}/${user.data.userLevel.level}`;
       navigator
         .share({
           title,


### PR DESCRIPTION
## 📌 제목

드로어에서 맵레벨 공유할 수 있도록 수정

## 📌 기타

유저 레벨을 알 수 없는 경우 클릭해도 아무 반응이 없는데, 어떻게 하면 좋을까요?